### PR TITLE
Add in small note in Readme regarding import of files containing even…

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Sparkles exports a function that returns a singleton `EventEmitter`.
 This EE can be shared across your application, whether or not node loads
 multiple copies.
 
+Note: If you put an event handler in a file in your application, that file must be loaded in via an import somewhere in your application, even if it's not directly being used. Otherwise, it will not be loaded into memory.
+
 ```js
 var sparkles = require('sparkles')(); // make sure to call the function
 


### PR DESCRIPTION
I am using this library for work. I put all my event handlers in another file from the one I was using, but didn't import the file anywhere else in my project and was stuck for a few hours (the event handlers were never loaded into memory, so I was emitting an event that had no handler). I put a short note in the readme - hopefully it can save others some time :)